### PR TITLE
Set up Dependabot and yarn audit in CI

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,42 @@
+# Dependabot keeps our dependencies up to date and opens PRs when a new
+# version (especially a security fix) is available.
+# Docs: https://docs.github.com/code-security/dependabot/dependabot-version-updates
+version: 2
+updates:
+  # npm packages (Yarn 1)
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "America/Sao_Paulo"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "⬆️"
+      include: "scope"
+    # Group minor and patch updates into a single PR per group.
+    # Major updates still come as their own PR.
+    groups:
+      prod-minor-patch:
+        dependency-type: "production"
+        update-types:
+          - "minor"
+          - "patch"
+      dev-minor-patch:
+        dependency-type: "development"
+        update-types:
+          - "minor"
+          - "patch"
+
+  # GitHub Actions versions (so the workflows themselves stay current)
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "America/Sao_Paulo"
+    commit-message:
+      prefix: "⬆️"
+      include: "scope"

--- a/.github/scripts/audit.sh
+++ b/.github/scripts/audit.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Fail the CI if `yarn audit` reports any HIGH or CRITICAL advisory that
+# is NOT in the known/accepted allowlist below.
+#
+# Yarn 1's `yarn audit` exits non-zero whenever it finds anything, so we
+# capture the JSON output, filter it, and decide ourselves.
+
+set -uo pipefail
+
+cd "$(dirname "$0")/../.."
+
+# --- Allowlist ---------------------------------------------------------------
+# Known advisories we have accepted for now. Each entry must link to the
+# issue or PR that explains why. Remove entries here as soon as the upstream
+# fix lands.
+#
+# Tracked in: https://github.com/gaabscps/gabs-portifolio/issues/22
+# (all 14 are in `next@14.2.x` and only fixed in `next@15.5.x`)
+ALLOWLIST=(
+  GHSA-9g9p-9gw9-jx7f
+  GHSA-3x4c-7xq6-9pq8
+  GHSA-h64f-5h5j-jqjh
+  GHSA-36qx-fr4f-26g5
+  GHSA-3g8h-86w9-wvmq
+  GHSA-h25m-26qc-wcjf
+  GHSA-q4gf-8mx6-v5v3
+  GHSA-8h8q-6873-q5fj
+  GHSA-gx5p-jg67-6x7h
+  GHSA-ffhc-5mcf-pf4q
+  GHSA-c4j6-fc7j-m34r
+  GHSA-vfv6-92ff-j949
+  GHSA-wfc6-r584-vfw7
+  GHSA-ggv3-7p47-pfv8
+)
+
+ALLOW_REGEX="$(IFS='|'; echo "${ALLOWLIST[*]}")"
+
+# --- Run audit ---------------------------------------------------------------
+AUDIT_JSON="$(mktemp)"
+trap 'rm -f "$AUDIT_JSON"' EXIT
+
+yarn audit --json > "$AUDIT_JSON" || true
+
+# --- Filter ------------------------------------------------------------------
+# Pick high + critical advisories, dedupe by GHSA id, drop allowlisted ones.
+NEW="$(
+  jq -r '
+    select(.type == "auditAdvisory")
+    | .data.advisory
+    | select(.severity == "high" or .severity == "critical")
+    | "\(.severity)\t\(.github_advisory_id)\t\(.module_name)\t\(.title)"
+  ' "$AUDIT_JSON" \
+  | sort -u \
+  | grep -vE "	($ALLOW_REGEX)	" || true
+)"
+
+# --- Report ------------------------------------------------------------------
+echo "=== yarn audit summary ==="
+yarn audit --summary 2>&1 | tail -3 || true
+echo
+echo "=== Allowlisted advisories (kept passing) ==="
+printf '%s\n' "${ALLOWLIST[@]}"
+echo
+
+if [[ -z "$NEW" ]]; then
+  echo "✅ No new high or critical advisories outside the allowlist."
+  exit 0
+fi
+
+echo "❌ Found high/critical advisories that are NOT in the allowlist:"
+echo
+printf '%s\n' "$NEW" | column -t -s $'\t'
+echo
+echo "Fix them, or — if you have reviewed the risk and want to defer —"
+echo "add the GHSA id to ALLOWLIST in .github/scripts/audit.sh with a"
+echo "link to the issue tracking it."
+exit 1

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,0 +1,28 @@
+name: audit
+
+# Run on PRs, on pushes to master, and once a week so we still catch
+# new advisories on packages we haven't touched.
+on:
+  pull_request:
+  push:
+    branches: [master]
+  schedule:
+    - cron: "0 9 * * 1" # Monday 09:00 UTC (06:00 America/Sao_Paulo)
+  workflow_dispatch:
+
+jobs:
+  yarn-audit:
+    name: yarn audit (fails on high or critical)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "yarn"
+
+      - run: yarn install --frozen-lockfile
+
+      - name: Run yarn audit and fail on new high/critical advisories
+        run: bash .github/scripts/audit.sh


### PR DESCRIPTION
## Summary

Adds the automated dependency checks that were missing — so the next time something like #17/#18/#19 happens, we hear about it from CI instead of finding it by hand.

Closes #20.

> Built on top of #21 — please merge that one first so the audit job starts with a clean baseline.

## What's in

### `.github/dependabot.yml`
- Watches `npm` (Yarn 1) and `github-actions`.
- Weekly on Monday 06:00 America/Sao_Paulo.
- Minor and patch updates are **grouped** into one PR per dependency type (prod / dev). Major updates still come as their own PR so they get a proper review.
- Commits prefixed with `⬆️` to match the repo's commit style.

### `.github/workflows/audit.yml`
- Runs `yarn audit` on every PR, on push to `master`, and weekly.
- Calls `.github/scripts/audit.sh`, which is where the real logic lives.

### `.github/scripts/audit.sh`
- Captures `yarn audit --json`.
- Fails CI on any `high` or `critical` advisory **that is not in the allowlist**.
- Allowlist is an explicit, commented array of GHSA ids. Today it holds 14 entries — all on `next@14.2.x`, all tracked in #22. The script prints the allowlist on every run so it's visible.

## Why an allowlist instead of just `yarn audit --level high`

The 14 known advisories on `next` are accepted on purpose (see #17 / #22). With a flat `--level high`, every CI run would fail and people would learn to ignore the red mark. The allowlist makes "we know about this one" explicit and forces a code change (add the GHSA id + link the issue) to silence anything new.

## Test plan

- [x] Workflow + script run locally — script reports the 14 allowlisted advisories and exits 0
- [x] YAML files parse cleanly
- [ ] On PR open, the `audit` workflow runs and passes (will verify once merged into a PR)
- [ ] After merge, confirm Dependabot opens its first batch on the next Monday
- [ ] (Repo setting, not in this PR) — Settings → Code security → enable Dependabot alerts and security updates