### PR TITLE
Skip major-version Dependabot bumps that need manual migration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,6 +28,29 @@ updates:
         update-types:
           - "minor"
           - "patch"
+    # Skip major bumps for packages that need a manual migration.
+    # We'll opt in to these upgrades by hand when ready.
+    ignore:
+      - dependency-name: "@chakra-ui/*"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@types/node"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "react"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "react-dom"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@types/react"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@types/react-dom"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "next"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "eslint"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "eslint-config-next"
+        update-types: ["version-update:semver-major"]
 
   # GitHub Actions versions (so the workflows themselves stay current)
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
## Summary

- Tells Dependabot to **skip major version bumps** (the kind that change the first number, like `2.x → 3.x`) for packages that need a manual migration.
- Minor and patch updates still flow through automatically — the security value of Dependabot is unchanged.
- We'll opt in to each major upgrade by hand, when we have time to update the code that breaks.

## Why

PRs #29 (Chakra UI 2 → 3) and #30 (TypeScript 5 → 6) both failed the Vercel build. They are major bumps with breaking changes that Dependabot can't fix on its own — the codebase still uses the old API. Without this rule, the same kind of PR will keep coming back every time a new major is released.

## Packages skipped for majors

`@chakra-ui/*`, `typescript`, `@types/node`, `react`, `react-dom`, `@types/react`, `@types/react-dom`, `next`, `eslint`, `eslint-config-next`.

## Test plan

- [x] YAML parses (Dependabot will validate on next run; syntax mirrors the existing block).
- [ ] After merge, close #29 and #30.