### PR TITLE
feat: add perf tooling and SEO docs; revert proposed next/image migration (data-driven)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@
 /.next/
 /out/
 
+# perf reports (lighthouse + bundle analyzer)
+/lighthouse-reports/
+
 # production
 /build
 
@@ -34,3 +37,13 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# AI
+CLAUDE.md
+docs/superpowers
+
+# ai-squad per-repo hook install (managed by `ai-squad deploy`)
+.claude/hooks/
+
+# ai-squad SDD per-session state
+.agent-session/

--- a/README.md
+++ b/README.md
@@ -148,6 +148,53 @@ The `Project` type in `src/types/project.ts` is the source of truth — TypeScri
 | Image **empty states** & fallbacks (#12) |  |
 | **Dependabot** + audit CI (#20) |  |
 
+## 🔎 SEO setup
+
+The site ships with the SEO floor in code (per-route metadata, sitemap, robots, JSON-LD, OG image, semantic headings). To make the site actually appear in Google, you still need to register the domain with **Google Search Console** and submit the sitemap. The steps below are a one-time setup.
+
+### 1. Verify ownership in Google Search Console
+
+Open [search.google.com/search-console](https://search.google.com/search-console) and add a new property using **Domain** (preferred over URL prefix — it covers `https://`, `https://www.`, and subdomains in one go).
+
+You get two verification options. Pick **one**:
+
+**Option A — DNS TXT record (preferred).** GSC shows you a token like `google-site-verification=abc123...`. Add it as a TXT record on the root of `gabrielandrade.net` in your DNS provider:
+
+| Host | Type | Value |
+|---|---|---|
+| `@` | `TXT` | `google-site-verification=<token-from-GSC>` |
+
+Wait 5–60 minutes for propagation, then click **Verify** in GSC.
+
+**Option B — HTML file (fallback).** GSC offers a file named `google<hash>.html`. Download it, place it under `public/`, commit, deploy. The file becomes available at `https://gabrielandrade.net/google<hash>.html`. Click **Verify** in GSC.
+
+### 2. Submit the sitemap
+
+In GSC: **Sitemaps → Add a new sitemap**, enter:
+
+```
+https://gabrielandrade.net/sitemap.xml
+```
+
+Status should turn to **Success** within minutes. The sitemap is generated at build time by `src/app/sitemap.ts`; new routes appear automatically on the next deploy.
+
+### 3. Monitor indexing
+
+| Where | What to look for |
+|---|---|
+| **Pages** (left sidebar) | "Indexed" count over time. Expect 0 on day 1, full count after a few weeks. |
+| **Pages → Not indexed** | Lists pages Google found but did not index, with a reason per page. |
+| **URL Inspection** (top bar) | Paste any URL to see its indexing status and request an index re-check. |
+
+Common errors and what they mean (in plain English):
+
+- **"Discovered — currently not indexed"** — Google knows the URL exists but has not crawled it yet. Patience usually fixes it (days to weeks for a new domain).
+- **"Crawled — currently not indexed"** — Google crawled the page but decided not to index it. Usually a sign the page is too thin / too similar to another. Add more content or merge with a stronger page.
+- **"Soft 404"** — Google thinks the page is empty even though it returned 200. Check for missing `<h1>` or near-empty body.
+- **"Page with redirect"** — informational; the URL redirects to another (e.g., `www.` to non-`www.`). Safe to ignore if intentional.
+
+A brand-new domain typically takes **2–8 weeks** to fully index. The single biggest accelerator is inbound links (your LinkedIn / GitHub README / Dev.to profile linking to `gabrielandrade.net`).
+
 ## 📬 Get in touch
 
 <p>

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,4 +1,10 @@
+import withBundleAnalyzerImport from "@next/bundle-analyzer";
+
+const withBundleAnalyzer = withBundleAnalyzerImport({
+  enabled: process.env.ANALYZE === "true",
+});
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {};
 
-export default nextConfig;
+export default withBundleAnalyzer(nextConfig);

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "perf:lighthouse": "bash scripts/perf-lighthouse.sh"
   },
   "dependencies": {
     "@chakra-ui/next-js": "^2.4.4",
@@ -20,6 +21,7 @@
     "react-icons": "^5.6.0"
   },
   "devDependencies": {
+    "@next/bundle-analyzer": "^16.2.6",
     "@types/node": "^25",
     "@types/react": "^18",
     "@types/react-dom": "^18",

--- a/scripts/perf-lighthouse.sh
+++ b/scripts/perf-lighthouse.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Run Lighthouse against the five public routes against a local production build.
+# Reports are written to lighthouse-reports/ (gitignored).
+# Per-route Chrome failures are logged to stderr and do not abort the rest.
+#
+# Usage: yarn perf:lighthouse
+# Prereq: yarn build && yarn start in another shell (or set BASE_URL).
+
+set -u
+
+BASE_URL="${BASE_URL:-http://localhost:3000}"
+OUT_DIR="lighthouse-reports"
+ROUTES=("/" "/about" "/projects" "/playx1" "/banca-do-ingresso")
+
+mkdir -p "$OUT_DIR"
+
+for route in "${ROUTES[@]}"; do
+  slug=$(echo "$route" | sed 's#/#_#g; s/^_$/root/; s/^_//')
+  url="${BASE_URL}${route}"
+  echo "[lighthouse] $url"
+  npx --yes lighthouse "$url" \
+    --quiet \
+    --chrome-flags="--headless --no-sandbox" \
+    --output=json \
+    --output=html \
+    --output-path="${OUT_DIR}/${slug}" \
+    --only-categories=performance \
+    || echo "[lighthouse] FAILED on $url (continuing)" >&2
+done
+
+echo "[lighthouse] done. Reports under ${OUT_DIR}/"

--- a/yarn.lock
+++ b/yarn.lock
@@ -127,6 +127,11 @@
     "@types/lodash.mergewith" "4.6.9"
     lodash.mergewith "4.6.2"
 
+"@discoveryjs/json-ext@0.5.7":
+  version "0.5.7"
+  resolved "https://registry.yarnpkg.com/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz#1d572bfbbe14b7704e0ba0f39b74815b84870d70"
+  integrity sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==
+
 "@emnapi/runtime@^1.7.0":
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/@emnapi/runtime/-/runtime-1.10.0.tgz#4b260c0d3534204e98c6110b8db1a987d26ec87c"
@@ -463,6 +468,13 @@
     wrap-ansi "^8.1.0"
     wrap-ansi-cjs "npm:wrap-ansi@^7.0.0"
 
+"@next/bundle-analyzer@^16.2.6":
+  version "16.2.6"
+  resolved "https://registry.yarnpkg.com/@next/bundle-analyzer/-/bundle-analyzer-16.2.6.tgz#887665657664f7f540e9942608c7c24040f85029"
+  integrity sha512-amPkVtHCTJAdBwyhhl5+qztHk24O4JlASgrWqh15AmnYi74apfZR46NGC0u4pM6BMAU1mYld4WdzD3cRBP3dOA==
+  dependencies:
+    webpack-bundle-analyzer "4.10.1"
+
 "@next/env@15.5.18":
   version "15.5.18"
   resolved "https://registry.yarnpkg.com/@next/env/-/env-15.5.18.tgz#207ab150d3f1c787ac343946155392d478506c1b"
@@ -540,6 +552,11 @@
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/@pkgjs/parseargs/-/parseargs-0.11.0.tgz#a77ea742fab25775145434eb1d2328cf5013ac33"
   integrity sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==
+
+"@polka/url@^1.0.0-next.24":
+  version "1.0.0-next.29"
+  resolved "https://registry.yarnpkg.com/@polka/url/-/url-1.0.0-next.29.tgz#5a40109a1ab5f84d6fd8fc928b19f367cbe7e7b1"
+  integrity sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==
 
 "@popperjs/core@^2.11.8":
   version "2.11.8"
@@ -740,6 +757,18 @@ acorn-jsx@^5.3.2:
   version "5.3.2"
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.3.2.tgz#7ed5bb55908b3b2f1bc55c6af1653bada7f07937"
   integrity sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==
+
+acorn-walk@^8.0.0:
+  version "8.3.5"
+  resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-8.3.5.tgz#8a6b8ca8fc5b34685af15dabb44118663c296496"
+  integrity sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==
+  dependencies:
+    acorn "^8.11.0"
+
+acorn@^8.0.4, acorn@^8.11.0:
+  version "8.16.0"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.16.0.tgz#4ce79c89be40afe7afe8f3adb902a1f1ce9ac08a"
+  integrity sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==
 
 acorn@^8.9.0:
   version "8.11.3"
@@ -1096,6 +1125,11 @@ color2k@^2.0.2:
   resolved "https://registry.yarnpkg.com/color2k/-/color2k-2.0.3.tgz#a771244f6b6285541c82aa65ff0a0c624046e533"
   integrity sha512-zW190nQTIoXcGCaU08DvVNFTmQhUpnJfVuAKfWqUQkflXKpaDdpaYoM0iluLS9lgJNHyBF58KKA2FBEwkD7wog==
 
+commander@^7.2.0:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-7.2.0.tgz#a36cb57d0b501ce108e4d20559a150a391d97ab7"
+  integrity sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==
+
 convert-source-map@^1.5.0:
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.9.0.tgz#7faae62353fb4213366d0ca98358d22e8368b05f"
@@ -1164,6 +1198,11 @@ data-view-byte-offset@^1.0.1:
     call-bound "^1.0.2"
     es-errors "^1.3.0"
     is-data-view "^1.0.1"
+
+debounce@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/debounce/-/debounce-1.2.1.tgz#38881d8f4166a5c5848020c11827b834bcb3e0a5"
+  integrity sha512-XRRe6Glud4rd/ZGQfiV1ruXSfbvfJedlV9Y6zOlP+2K04vBYiJEte6stfFkCP03aMnY5tsipamumUjL14fofug==
 
 debug@^3.2.7:
   version "3.2.7"
@@ -1250,6 +1289,11 @@ dunder-proto@^1.0.0, dunder-proto@^1.0.1:
     call-bind-apply-helpers "^1.0.1"
     es-errors "^1.3.0"
     gopd "^1.2.0"
+
+duplexer@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/duplexer/-/duplexer-0.1.2.tgz#3abe43aef3835f8ae077d136ddce0f276b0400e6"
+  integrity sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==
 
 eastasianwidth@^0.2.0:
   version "0.2.0"
@@ -2008,6 +2052,13 @@ graphemer@^1.4.0:
   resolved "https://registry.yarnpkg.com/graphemer/-/graphemer-1.4.0.tgz#fb2f1d55e0e3a1849aeffc90c4fa0dd53a0e66c6"
   integrity sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==
 
+gzip-size@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/gzip-size/-/gzip-size-6.0.0.tgz#065367fd50c239c0671cbcbad5be3e2eeb10e462"
+  integrity sha512-ax7ZYomf6jqPTQ4+XCpUGyXKHk5WweS+e05MBO4/y3WJ5RkmPXNKvX+bx1behVILVwr6JSQvZAku021CHPXG3Q==
+  dependencies:
+    duplexer "^0.1.2"
+
 has-bigints@^1.0.1, has-bigints@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/has-bigints/-/has-bigints-1.0.2.tgz#0871bd3e3d51626f6ca0966668ba35d5602d6eaa"
@@ -2091,6 +2142,11 @@ hoist-non-react-statics@^3.3.1:
   integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
   dependencies:
     react-is "^16.7.0"
+
+html-escaper@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/html-escaper/-/html-escaper-2.0.2.tgz#dfd60027da36a36dfcbe236262c00a5822681453"
+  integrity sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==
 
 ignore@^5.2.0:
   version "5.3.1"
@@ -2306,6 +2362,11 @@ is-path-inside@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/is-path-inside/-/is-path-inside-3.0.3.tgz#d231362e53a07ff2b0e0ea7fed049161ffd16283"
   integrity sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==
+
+is-plain-object@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/is-plain-object/-/is-plain-object-5.0.0.tgz#4427f50ab3429e9025ea7d52e9043a9ef4159344"
+  integrity sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==
 
 is-regex@^1.1.4:
   version "1.1.4"
@@ -2609,6 +2670,11 @@ motion-utils@^12.36.0:
   resolved "https://registry.yarnpkg.com/motion-utils/-/motion-utils-12.36.0.tgz#cff2df2a28c3fe53a3de7e0103ba7f73ff7d77a7"
   integrity sha512-eHWisygbiwVvf6PZ1vhaHCLamvkSbPIeAYxWUuL3a2PD/TROgE7FvfHWTIH4vMl798QLfMw15nRqIaRDXTlYRg==
 
+mrmime@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/mrmime/-/mrmime-2.0.1.tgz#bc3e87f7987853a54c9850eeb1f1078cd44adddc"
+  integrity sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==
+
 ms@2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
@@ -2750,6 +2816,11 @@ object.values@^1.2.1:
     define-properties "^1.2.1"
     es-object-atoms "^1.0.0"
 
+opener@^1.5.2:
+  version "1.5.2"
+  resolved "https://registry.yarnpkg.com/opener/-/opener-1.5.2.tgz#5d37e1f35077b9dcac4301372271afdeb2a13598"
+  integrity sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==
+
 optionator@^0.9.3:
   version "0.9.3"
   resolved "https://registry.yarnpkg.com/optionator/-/optionator-0.9.3.tgz#007397d44ed1872fdc6ed31360190f81814e2c64"
@@ -2835,7 +2906,7 @@ path-type@^4.0.0:
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-4.0.0.tgz#84ed01c0a7ba380afe09d90a8c180dcd9d03043b"
   integrity sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==
 
-picocolors@^1.1.1:
+picocolors@^1.0.0, picocolors@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.1.1.tgz#3d321af3eab939b083c8f929a1d12cda81c26b6b"
   integrity sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==
@@ -3259,6 +3330,15 @@ signal-exit@^4.0.1:
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-4.1.0.tgz#952188c1cbd546070e2dd20d0f41c0ae0530cb04"
   integrity sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==
 
+sirv@^2.0.3:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/sirv/-/sirv-2.0.4.tgz#5dd9a725c578e34e449f332703eb2a74e46a29b0"
+  integrity sha512-94Bdh3cC2PKrbgSOUqTiGPWVZeSiXfKOVZNJniWoqrWrRkB1CJzBU3NEbiTsPcYy1lDsANA/THzS+9WBiy5nfQ==
+  dependencies:
+    "@polka/url" "^1.0.0-next.24"
+    mrmime "^2.0.0"
+    totalist "^3.0.0"
+
 source-map-js@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.2.1.tgz#1ce5650fddd87abc099eda37dcff024c2667ae46"
@@ -3277,16 +3357,7 @@ stop-iteration-iterator@^1.1.0:
     es-errors "^1.3.0"
     internal-slot "^1.1.0"
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-string-width@^4.1.0:
+"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -3399,14 +3470,7 @@ string.prototype.trimstart@^1.0.8:
     define-properties "^1.2.1"
     es-object-atoms "^1.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -3495,6 +3559,11 @@ toggle-selection@^1.0.6:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/toggle-selection/-/toggle-selection-1.0.6.tgz#6e45b1263f2017fa0acc7d89d78b15b8bf77da32"
   integrity sha512-BiZS+C1OS8g/q2RRbJmy59xpyghNBqrr6k5L/uKBGRsTfxmu3ffiRnd8mlGPUVayg8pvfi5urfnu8TU7DVOkLQ==
+
+totalist@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/totalist/-/totalist-3.0.1.tgz#ba3a3d600c915b1a97872348f79c127475f6acf8"
+  integrity sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==
 
 ts-api-utils@^2.5.0:
   version "2.5.0"
@@ -3669,6 +3738,25 @@ use-sidecar@^1.1.3:
     detect-node-es "^1.1.0"
     tslib "^2.0.0"
 
+webpack-bundle-analyzer@4.10.1:
+  version "4.10.1"
+  resolved "https://registry.yarnpkg.com/webpack-bundle-analyzer/-/webpack-bundle-analyzer-4.10.1.tgz#84b7473b630a7b8c21c741f81d8fe4593208b454"
+  integrity sha512-s3P7pgexgT/HTUSYgxJyn28A+99mmLq4HsJepMPzu0R8ImJc52QNqaFYW1Z2z2uIb1/J3eYgaAWVpaC+v/1aAQ==
+  dependencies:
+    "@discoveryjs/json-ext" "0.5.7"
+    acorn "^8.0.4"
+    acorn-walk "^8.0.0"
+    commander "^7.2.0"
+    debounce "^1.2.1"
+    escape-string-regexp "^4.0.0"
+    gzip-size "^6.0.0"
+    html-escaper "^2.0.2"
+    is-plain-object "^5.0.0"
+    opener "^1.5.2"
+    picocolors "^1.0.0"
+    sirv "^2.0.3"
+    ws "^7.3.1"
+
 which-boxed-primitive@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz#13757bc89b209b049fe5d86430e21cf40a89a8e6"
@@ -3768,6 +3856,11 @@ wrap-ansi@^8.1.0:
     ansi-styles "^6.1.0"
     string-width "^5.0.1"
     strip-ansi "^7.0.1"
+
+ws@^7.3.1:
+  version "7.5.10"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-7.5.10.tgz#58b5c20dc281633f6c19113f39b349bd8bd558d9"
+  integrity sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==
 
 yaml@^1.10.0, yaml@^1.10.3:
   version "1.10.3"


### PR DESCRIPTION
Closes #41.

## Summary

The original issue (#41) proposed migrating Chakra `<Image>` to `next/image` for hero and screenshot images, on the hypothesis that Chakra's `<img>` without `width`/`height` was hurting CLS. I implemented the migration, then ran Lighthouse before and after to verify. **The numbers showed the migration made performance worse on every route**, so it was reverted. The PR ships only the parts that survive the data: measurement tooling and SEO docs.

## What this PR ships

| Change | Reason |
|---|---|
| `@next/bundle-analyzer` wired in `next.config.mjs`, gated by `ANALYZE` env var | Lets us inspect the bundle later. Zero runtime cost when unset (verified — bundle sizes identical to master). |
| `scripts/perf-lighthouse.sh` + `yarn perf:lighthouse` | Reproducible Lighthouse runs across the five public routes. Per-route failure isolation. |
| `README.md` — new "SEO setup" section | Walks through Google Search Console verification, sitemap submission, monitoring common indexing errors. |
| `.gitignore` — `lighthouse-reports/`, `.agent-session/` | Tooling outputs. |

## What this PR does NOT ship (and why)

Originally migrated five components to `next/image` (profile photo, `ProjectCard` cover, three PlayX1 screenshots, three Banca screenshots). Measured the result against the master baseline. The migration regressed every single route:

| Route | Master (baseline) | After migration | Verdict |
|---|---|---|---|
| `/` | LCP 2.61s, CLS **0**, TBT **0ms**, Perf **93** | LCP 1.89s, CLS 0.003, TBT 892ms, Perf 79 | LCP improved, but TBT exploded and Perf dropped 14 points. |
| `/about` | LCP 2.85s, CLS **0**, Perf **94** | LCP 2.51s, CLS 0.003, Perf 77 | Same shape. |
| `/projects` | LCP 2.64s, CLS **0**, Perf **96** | LCP 3.41s, CLS **0.401**, Perf **53** | Catastrophic. The fill-mode container interacted badly with the existing mobile flex layout. |
| `/playx1` | LCP 1.91s, CLS **0**, Perf **100** | LCP 2.53s, CLS 0.003, Perf 81 | Regression with no upside. |
| `/banca-do-ingresso` | LCP 1.61s, CLS **0**, Perf **100** | LCP 2.58s, CLS 0.003, Perf 77 | Same. |

### Why the original hypothesis was wrong

The Chakra `<Image>` calls in this codebase all sit inside parent `<Box>` containers with explicit `width` and `height`. That gives the browser a stable layout box before the image bytes arrive, so CLS stays at 0 even though the `<img>` itself has no intrinsic dimensions. The hypothesis "Chakra Image hurts CLS" assumed the image element itself was responsible, but the surrounding layout was already doing the work.

The cost of switching to `next/image` is the optimizer's runtime JavaScript on every page — about ~800ms of Total Blocking Time on this codebase. There was no CLS to fix, so there is no benefit to trade for that cost.

### About the use-client audit (US-003 in the SDD plan)

I audited every `.tsx` under `src/` with `"use client"` (11 files). Every directive is justified by an active hook (`useMediaQuery`, `useState`, `useEffect`, `useDisclosure`, `usePathname`, custom hooks that wrap those) or by event handlers. Zero safe removals. The blocker is Chakra's `useMediaQuery` — moving off it to CSS media queries would unlock several files but is explicitly out of scope per the spec (would be its own larger refactor). Recording this finding here so it does not get re-investigated later.

## What the closing comment on #41 will contain

The full per-route Lighthouse JSON output for both runs (committed to my local machine; the comment summarizes the table above and links each AC from the spec to its outcome).

## Test plan

- [x] `yarn build` passes; bundle sizes identical to master (`140B` for `/`, etc).
- [x] `ANALYZE=true yarn build` produces analyzer reports under `.next/analyze/`.
- [x] `yarn perf:lighthouse` runs against `yarn start` and writes reports under `lighthouse-reports/` for each of the five routes.
- [ ] After merge: run the README "SEO setup" steps against the live domain (one-time setup, manual).