### PR TITLE
Full case studies for soundwave and ai-squad

### DIFF
--- a/public/ai-squad/build-pipeline.svg
+++ b/public/ai-squad/build-pipeline.svg
@@ -1,0 +1,83 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 860 220" width="860" height="220">
+  <defs>
+    <linearGradient id="bg2" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#0f172a"/>
+      <stop offset="100%" style="stop-color:#1e293b"/>
+    </linearGradient>
+    <marker id="arr2" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto">
+      <path d="M0,0 L0,6 L8,3 z" fill="#475569"/>
+    </marker>
+    <marker id="arr3" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto">
+      <path d="M0,0 L0,6 L8,3 z" fill="#f59e0b"/>
+    </marker>
+  </defs>
+
+  <rect width="860" height="220" fill="url(#bg2)" rx="12"/>
+
+  <!-- Title -->
+  <text x="430" y="30" text-anchor="middle" fill="#94a3b8" font-family="-apple-system,BlinkMacSystemFont,sans-serif" font-size="13" font-weight="600">Build Phase — runs autonomously per task</text>
+
+  <!-- Orchestrator -->
+  <rect x="30" y="80" width="110" height="60" rx="8" fill="#1e3a5f" stroke="#3b82f6" stroke-width="1.5"/>
+  <text x="85" y="106" text-anchor="middle" fill="#93c5fd" font-family="-apple-system,BlinkMacSystemFont,sans-serif" font-size="11" font-weight="700">orchestrator</text>
+  <text x="85" y="124" text-anchor="middle" fill="#64748b" font-family="monospace" font-size="10">dispatches</text>
+
+  <!-- Arrow to dev -->
+  <path d="M 146 110 L 186 110" stroke="#475569" stroke-width="1.5" marker-end="url(#arr2)"/>
+
+  <!-- Dev -->
+  <rect x="190" y="80" width="100" height="60" rx="8" fill="#1c1917" stroke="#78716c" stroke-width="1.5"/>
+  <text x="240" y="104" text-anchor="middle" fill="#d6d3d1" font-family="-apple-system,BlinkMacSystemFont,sans-serif" font-size="11" font-weight="700">dev</text>
+  <text x="240" y="120" text-anchor="middle" fill="#78716c" font-family="monospace" font-size="10">implements</text>
+  <text x="240" y="134" text-anchor="middle" fill="#78716c" font-family="monospace" font-size="9">+ tests</text>
+
+  <!-- Arrow to reviewers (split) -->
+  <path d="M 296 95 L 336 70" stroke="#475569" stroke-width="1.5" marker-end="url(#arr2)"/>
+  <path d="M 296 125 L 336 150" stroke="#475569" stroke-width="1.5" marker-end="url(#arr2)"/>
+
+  <!-- Parallel label -->
+  <text x="316" y="112" text-anchor="middle" fill="#334155" font-family="monospace" font-size="9">parallel</text>
+
+  <!-- Code reviewer -->
+  <rect x="340" y="44" width="120" height="52" rx="8" fill="#1e293b" stroke="#a855f7" stroke-width="1.5"/>
+  <text x="400" y="66" text-anchor="middle" fill="#c4b5fd" font-family="-apple-system,BlinkMacSystemFont,sans-serif" font-size="10" font-weight="700">code-reviewer</text>
+  <text x="400" y="82" text-anchor="middle" fill="#7c3aed" font-family="monospace" font-size="9">patterns · style</text>
+
+  <!-- Logic reviewer -->
+  <rect x="340" y="124" width="120" height="52" rx="8" fill="#1e293b" stroke="#ec4899" stroke-width="1.5"/>
+  <text x="400" y="146" text-anchor="middle" fill="#f9a8d4" font-family="-apple-system,BlinkMacSystemFont,sans-serif" font-size="10" font-weight="700">logic-reviewer</text>
+  <text x="400" y="162" text-anchor="middle" fill="#be185d" font-family="monospace" font-size="9">edge cases · races</text>
+
+  <!-- Merge back + loop arrow -->
+  <path d="M 466 70 L 506 95" stroke="#475569" stroke-width="1.5" marker-end="url(#arr2)"/>
+  <path d="M 466 150 L 506 125" stroke="#475569" stroke-width="1.5" marker-end="url(#arr2)"/>
+
+  <!-- Findings gate -->
+  <rect x="510" y="80" width="110" height="60" rx="8" fill="#1e293b" stroke="#f59e0b" stroke-width="1.5"/>
+  <text x="565" y="104" text-anchor="middle" fill="#fcd34d" font-family="-apple-system,BlinkMacSystemFont,sans-serif" font-size="10" font-weight="700">findings?</text>
+  <text x="565" y="120" text-anchor="middle" fill="#78716c" font-family="monospace" font-size="9">loop back</text>
+  <text x="565" y="133" text-anchor="middle" fill="#78716c" font-family="monospace" font-size="9">max 3 rounds</text>
+
+  <!-- Loop back arrow (curved) -->
+  <path d="M 565 80 C 565 50, 240 50, 240 80" stroke="#f59e0b" stroke-width="1" stroke-dasharray="4,3" fill="none" marker-end="url(#arr3)"/>
+
+  <!-- Arrow to QA -->
+  <path d="M 626 110 L 666 110" stroke="#22c55e" stroke-width="1.5" marker-end="url(#arr2)"/>
+
+  <!-- QA -->
+  <rect x="670" y="80" width="100" height="60" rx="8" fill="#14532d" stroke="#22c55e" stroke-width="1.5"/>
+  <text x="720" y="104" text-anchor="middle" fill="#86efac" font-family="-apple-system,BlinkMacSystemFont,sans-serif" font-size="11" font-weight="700">qa</text>
+  <text x="720" y="120" text-anchor="middle" fill="#4ade80" font-family="monospace" font-size="9">validates each</text>
+  <text x="720" y="133" text-anchor="middle" fill="#4ade80" font-family="monospace" font-size="9">AC criterion</text>
+
+  <!-- Arrow to handoff -->
+  <path d="M 776 110 L 816 110" stroke="#22c55e" stroke-width="1.5" marker-end="url(#arr2)"/>
+
+  <!-- Handoff -->
+  <rect x="820" y="88" width="28" height="44" rx="6" fill="#166534" stroke="#22c55e" stroke-width="1.5"/>
+  <text x="834" y="106" text-anchor="middle" fill="#4ade80" font-family="monospace" font-size="14">✓</text>
+  <text x="834" y="122" text-anchor="middle" fill="#4ade80" font-family="monospace" font-size="8">done</text>
+
+  <!-- Bottom note -->
+  <text x="430" y="200" text-anchor="middle" fill="#334155" font-family="-apple-system,BlinkMacSystemFont,sans-serif" font-size="11">Up to 5 tasks run in parallel · any escalation goes to blocker-specialist · audit-agent gates the final handoff</text>
+</svg>

--- a/public/ai-squad/hero.svg
+++ b/public/ai-squad/hero.svg
@@ -1,0 +1,82 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 200" width="900" height="200">
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#0f172a"/>
+      <stop offset="100%" style="stop-color:#1e293b"/>
+    </linearGradient>
+    <linearGradient id="disc" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#1d4ed8"/>
+      <stop offset="100%" style="stop-color:#3b82f6"/>
+    </linearGradient>
+    <linearGradient id="sdd" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#d97706"/>
+      <stop offset="100%" style="stop-color:#f59e0b"/>
+    </linearGradient>
+    <filter id="glow">
+      <feGaussianBlur stdDeviation="3" result="coloredBlur"/>
+      <feMerge><feMergeNode in="coloredBlur"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+  </defs>
+
+  <!-- Background -->
+  <rect width="900" height="200" fill="url(#bg)" rx="12"/>
+
+  <!-- Step 1: Fuzzy idea -->
+  <rect x="28" y="68" width="110" height="64" rx="10" fill="#1e3a5f" stroke="#3b82f6" stroke-width="1.5"/>
+  <text x="83" y="93" text-anchor="middle" fill="#93c5fd" font-family="monospace" font-size="22">💡</text>
+  <text x="83" y="117" text-anchor="middle" fill="#94a3b8" font-family="-apple-system,BlinkMacSystemFont,sans-serif" font-size="11">Fuzzy idea</text>
+
+  <!-- Arrow 1 -->
+  <path d="M 144 100 L 168 100" stroke="#475569" stroke-width="2" marker-end="url(#arr)"/>
+
+  <!-- Discovery squad box -->
+  <rect x="172" y="44" width="170" height="112" rx="10" fill="#1e293b" stroke="#3b82f6" stroke-width="2"/>
+  <rect x="172" y="44" width="170" height="32" rx="10" fill="url(#disc)"/>
+  <rect x="172" y="60" width="170" height="16" fill="url(#disc)"/>
+  <text x="257" y="65" text-anchor="middle" fill="#fff" font-family="-apple-system,BlinkMacSystemFont,sans-serif" font-size="12" font-weight="700">🎯 Discovery</text>
+  <text x="257" y="88" text-anchor="middle" fill="#93c5fd" font-family="monospace" font-size="10">Frame</text>
+  <text x="257" y="103" text-anchor="middle" fill="#64748b" font-family="monospace" font-size="9">↓</text>
+  <text x="257" y="118" text-anchor="middle" fill="#93c5fd" font-family="monospace" font-size="10">Investigate</text>
+  <text x="257" y="133" text-anchor="middle" fill="#64748b" font-family="monospace" font-size="9">↓</text>
+  <text x="257" y="148" text-anchor="middle" fill="#93c5fd" font-family="monospace" font-size="10">Decide</text>
+
+  <!-- Arrow 2 -->
+  <path d="M 348 100 L 372 100" stroke="#475569" stroke-width="2" marker-end="url(#arr)"/>
+
+  <!-- Decision gate -->
+  <rect x="376" y="72" width="100" height="56" rx="10" fill="#1e293b" stroke="#22c55e" stroke-width="1.5"/>
+  <text x="426" y="97" text-anchor="middle" fill="#4ade80" font-family="monospace" font-size="18">✓</text>
+  <text x="426" y="116" text-anchor="middle" fill="#86efac" font-family="-apple-system,BlinkMacSystemFont,sans-serif" font-size="10">Your decision</text>
+
+  <!-- Arrow 3 -->
+  <path d="M 482 100 L 506 100" stroke="#475569" stroke-width="2" marker-end="url(#arr)"/>
+
+  <!-- SDD squad box -->
+  <rect x="510" y="44" width="170" height="112" rx="10" fill="#1e293b" stroke="#f59e0b" stroke-width="2"/>
+  <rect x="510" y="44" width="170" height="32" rx="10" fill="url(#sdd)"/>
+  <rect x="510" y="60" width="170" height="16" fill="url(#sdd)"/>
+  <text x="595" y="65" text-anchor="middle" fill="#fff" font-family="-apple-system,BlinkMacSystemFont,sans-serif" font-size="12" font-weight="700">🚢 SDD</text>
+  <text x="595" y="88" text-anchor="middle" fill="#fcd34d" font-family="monospace" font-size="10">Specify → Plan</text>
+  <text x="595" y="103" text-anchor="middle" fill="#64748b" font-family="monospace" font-size="9">↓</text>
+  <text x="595" y="118" text-anchor="middle" fill="#fcd34d" font-family="monospace" font-size="10">Tasks</text>
+  <text x="595" y="133" text-anchor="middle" fill="#64748b" font-family="monospace" font-size="9">↓</text>
+  <text x="595" y="148" text-anchor="middle" fill="#fcd34d" font-family="monospace" font-size="10">Build (auto)</text>
+
+  <!-- Arrow 4 -->
+  <path d="M 686 100 L 710 100" stroke="#475569" stroke-width="2" marker-end="url(#arr)"/>
+
+  <!-- Shipped -->
+  <rect x="714" y="68" width="110" height="64" rx="10" fill="#14532d" stroke="#22c55e" stroke-width="1.5"/>
+  <text x="769" y="93" text-anchor="middle" fill="#4ade80" font-family="monospace" font-size="22">🚀</text>
+  <text x="769" y="117" text-anchor="middle" fill="#86efac" font-family="-apple-system,BlinkMacSystemFont,sans-serif" font-size="11">Shipped code</text>
+
+  <!-- Arrow markers -->
+  <defs>
+    <marker id="arr" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto">
+      <path d="M0,0 L0,6 L8,3 z" fill="#475569"/>
+    </marker>
+  </defs>
+
+  <!-- Bottom label -->
+  <text x="450" y="185" text-anchor="middle" fill="#334155" font-family="-apple-system,BlinkMacSystemFont,sans-serif" font-size="11">Every gate is conversational — only Build runs unattended</text>
+</svg>

--- a/public/ai-squad/squads.svg
+++ b/public/ai-squad/squads.svg
@@ -1,0 +1,93 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 860 260" width="860" height="260">
+  <defs>
+    <linearGradient id="bg3" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#0f172a"/>
+      <stop offset="100%" style="stop-color:#1e293b"/>
+    </linearGradient>
+    <linearGradient id="dh" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#1d4ed8"/>
+      <stop offset="100%" style="stop-color:#3b82f6"/>
+    </linearGradient>
+    <linearGradient id="sh" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#d97706"/>
+      <stop offset="100%" style="stop-color:#f59e0b"/>
+    </linearGradient>
+  </defs>
+
+  <rect width="860" height="260" fill="url(#bg3)" rx="12"/>
+
+  <!-- Discovery Card -->
+  <rect x="30" y="30" width="380" height="200" rx="12" fill="#0f172a" stroke="#3b82f6" stroke-width="2"/>
+  <!-- Header -->
+  <rect x="30" y="30" width="380" height="46" rx="12" fill="url(#dh)"/>
+  <rect x="30" y="62" width="380" height="14" fill="url(#dh)"/>
+  <text x="220" y="58" text-anchor="middle" fill="#fff" font-family="-apple-system,BlinkMacSystemFont,sans-serif" font-size="15" font-weight="700">🎯  Discovery Squad</text>
+
+  <!-- Trigger label -->
+  <text x="220" y="96" text-anchor="middle" fill="#64748b" font-family="-apple-system,BlinkMacSystemFont,sans-serif" font-size="11">When you have a fuzzy idea — not sure if/what to build</text>
+
+  <!-- Phases -->
+  <!-- Phase 1 -->
+  <rect x="50" y="108" width="100" height="50" rx="8" fill="#1e3a5f" stroke="#3b82f6" stroke-width="1"/>
+  <text x="100" y="130" text-anchor="middle" fill="#93c5fd" font-family="-apple-system,BlinkMacSystemFont,sans-serif" font-size="10" font-weight="700">1 · Frame</text>
+  <text x="100" y="147" text-anchor="middle" fill="#64748b" font-family="monospace" font-size="9">/discovery-lead</text>
+
+  <text x="160" y="136" text-anchor="middle" fill="#475569" font-family="monospace" font-size="14">→</text>
+
+  <!-- Phase 2 -->
+  <rect x="170" y="108" width="100" height="50" rx="8" fill="#1e3a5f" stroke="#3b82f6" stroke-width="1"/>
+  <text x="220" y="130" text-anchor="middle" fill="#93c5fd" font-family="-apple-system,BlinkMacSystemFont,sans-serif" font-size="10" font-weight="700">2 · Investigate</text>
+  <text x="220" y="147" text-anchor="middle" fill="#64748b" font-family="monospace" font-size="9">5× parallel agents</text>
+
+  <text x="280" y="136" text-anchor="middle" fill="#475569" font-family="monospace" font-size="14">→</text>
+
+  <!-- Phase 3 -->
+  <rect x="290" y="108" width="100" height="50" rx="8" fill="#1e3a5f" stroke="#3b82f6" stroke-width="1"/>
+  <text x="340" y="130" text-anchor="middle" fill="#93c5fd" font-family="-apple-system,BlinkMacSystemFont,sans-serif" font-size="10" font-weight="700">3 · Decide</text>
+  <text x="340" y="147" text-anchor="middle" fill="#64748b" font-family="monospace" font-size="9">/discovery-synth</text>
+
+  <!-- Output label -->
+  <text x="220" y="185" text-anchor="middle" fill="#475569" font-family="-apple-system,BlinkMacSystemFont,sans-serif" font-size="11">Output: <tspan fill="#93c5fd">memo.md</tspan> — build / kill / pivot / defer</text>
+  <text x="220" y="204" text-anchor="middle" fill="#334155" font-family="-apple-system,BlinkMacSystemFont,sans-serif" font-size="10">You make the final call. Always.</text>
+
+  <!-- SDD Card -->
+  <rect x="450" y="30" width="380" height="200" rx="12" fill="#0f172a" stroke="#f59e0b" stroke-width="2"/>
+  <!-- Header -->
+  <rect x="450" y="30" width="380" height="46" rx="12" fill="url(#sh)"/>
+  <rect x="450" y="62" width="380" height="14" fill="url(#sh)"/>
+  <text x="640" y="58" text-anchor="middle" fill="#fff" font-family="-apple-system,BlinkMacSystemFont,sans-serif" font-size="15" font-weight="700">🚢  SDD Squad</text>
+
+  <!-- Trigger label -->
+  <text x="640" y="96" text-anchor="middle" fill="#64748b" font-family="-apple-system,BlinkMacSystemFont,sans-serif" font-size="11">When you know what to build — turns pitch into shipped code</text>
+
+  <!-- Phases -->
+  <!-- Phase 1 -->
+  <rect x="462" y="108" width="80" height="50" rx="8" fill="#1c1917" stroke="#f59e0b" stroke-width="1"/>
+  <text x="502" y="130" text-anchor="middle" fill="#fcd34d" font-family="-apple-system,BlinkMacSystemFont,sans-serif" font-size="10" font-weight="700">1 · Specify</text>
+  <text x="502" y="147" text-anchor="middle" fill="#64748b" font-family="monospace" font-size="9">/spec-writer</text>
+
+  <text x="552" y="136" text-anchor="middle" fill="#475569" font-family="monospace" font-size="14">→</text>
+
+  <!-- Phase 2 -->
+  <rect x="562" y="108" width="80" height="50" rx="8" fill="#1c1917" stroke="#f59e0b" stroke-width="1"/>
+  <text x="602" y="130" text-anchor="middle" fill="#fcd34d" font-family="-apple-system,BlinkMacSystemFont,sans-serif" font-size="10" font-weight="700">2 · Plan</text>
+  <text x="602" y="147" text-anchor="middle" fill="#64748b" font-family="monospace" font-size="9">/designer</text>
+
+  <text x="652" y="136" text-anchor="middle" fill="#475569" font-family="monospace" font-size="14">→</text>
+
+  <!-- Phase 3 -->
+  <rect x="662" y="108" width="80" height="50" rx="8" fill="#1c1917" stroke="#f59e0b" stroke-width="1"/>
+  <text x="702" y="130" text-anchor="middle" fill="#fcd34d" font-family="-apple-system,BlinkMacSystemFont,sans-serif" font-size="10" font-weight="700">3 · Tasks</text>
+  <text x="702" y="147" text-anchor="middle" fill="#64748b" font-family="monospace" font-size="9">/task-builder</text>
+
+  <text x="752" y="136" text-anchor="middle" fill="#475569" font-family="monospace" font-size="14">→</text>
+
+  <!-- Phase 4 -->
+  <rect x="762" y="108" width="58" height="50" rx="8" fill="#14532d" stroke="#22c55e" stroke-width="1.5"/>
+  <text x="791" y="130" text-anchor="middle" fill="#86efac" font-family="-apple-system,BlinkMacSystemFont,sans-serif" font-size="10" font-weight="700">4 · Build</text>
+  <text x="791" y="147" text-anchor="middle" fill="#4ade80" font-family="monospace" font-size="9">autonomous</text>
+
+  <!-- Output label -->
+  <text x="640" y="185" text-anchor="middle" fill="#475569" font-family="-apple-system,BlinkMacSystemFont,sans-serif" font-size="11">Output: <tspan fill="#fcd34d">code + tests</tspan> in your repo, ready to review</text>
+  <text x="640" y="204" text-anchor="middle" fill="#334155" font-family="-apple-system,BlinkMacSystemFont,sans-serif" font-size="10">Phases 1–3 require your sign-off. Phase 4 runs unattended.</text>
+</svg>

--- a/src/app/work/[slug]/page.tsx
+++ b/src/app/work/[slug]/page.tsx
@@ -29,6 +29,12 @@ const HEADLINES: Record<string, React.ReactNode> = {
       <Box as="span" className="serif-italic" color="brand.accent" fontWeight="600">actually</Box> use.
     </>
   ),
+  "ai-squad": (
+    <>
+      A workflow that survives me{" "}
+      <Box as="span" className="serif-italic" color="brand.accent" fontWeight="600">forgetting</Box> to be disciplined.
+    </>
+  ),
   calendarfr: (
     <>
       A planner that{" "}
@@ -41,7 +47,9 @@ const LEDES: Record<string, string> = {
   bettersmp:
     "BetterSMP is a Minecraft multiplayer server I run with my brother — 33 custom Java plugins on top of the vanilla game. Popular servers turn into idle farms (players leave the game running overnight for rewards); we wanted somewhere with actual gameplay, and the only way to get it was to write the gameplay. AI writes every line of Java. I write the architecture, the security model, and the calls that decide if it's fun.",
   soundwave:
-    "I take a lot of meetings. I miss a lot of details. soundwave records, transcribes, and surfaces the parts I'd otherwise lose — and grades how I sound on the parts I want to improve.",
+    "I take a lot of meetings. I miss a lot of details. soundwave records, transcribes, and surfaces the parts I'd otherwise lose — topics, decisions, action items — and grades how I sound on the parts I want to improve.",
+  "ai-squad":
+    "AI coding tools are powerful but unstructured. ai-squad adds the missing layer: interactive spec gates, parallel autonomous review, and a mechanical audit trail enforced by runtime hooks — so the loop survives me trusting it unattended.",
   calendarfr:
     "Every year I'd buy a planner and abandon it by February — too lazy to dig through a bag to find it. CalendarFR lives where I already am.",
 };

--- a/src/data/projects.tsx
+++ b/src/data/projects.tsx
@@ -492,17 +492,153 @@ export const projects: Project[] = [
     slug: "soundwave",
     translationKey: "soundwave",
     year: "2026",
-    startedAt: "2025-11",
-    category: "personal tool",
+    startedAt: "2025-12",
+    category: "audio AI platform",
     images: [],
-    skills: [skills.react, skills.next, skills.typescript],
-    links: { route: "/work/soundwave" },
+    skills: [skills.react, skills.typescript, skills.github],
+    links: {
+      route: "/work/soundwave",
+      github: "https://github.com/gaabscps/soundwave-summit",
+    },
     status: "live",
+    // To swap the cover to a recording-flow video (kind: "video"), drop the file at
+    // public/soundwave/preview.mp4 and update the cover to:
+    //   cover: { kind: "video", src: "/soundwave/preview.mp4", alt: "SoundWave Summit — 20s recording flow: hit record → speak → stop → analysis appears with topics, decisions, action items" },
     cover: { kind: "custom", component: "Waveform" },
-    stackChips: ["Next", "Whisper"],
+    stackChips: ["Vite + React", "Supabase", "Google AI"],
     aiTool: "Claude",
     motivation:
       "I kept losing the good parts of meetings. Built a pipeline to surface what I missed.",
+    motivationContext: "— december 2025, after the third meeting I couldn't remember the next morning",
+    buildLog: [
+      {
+        date: "2025-12-10",
+        version: "v0.1",
+        title: "Scaffolded on Lovable. SaaS UI for audio in one evening.",
+        body: "Started from a Vite + React + shadcn template through Lovable Cloud — the entire UI shell, auth shapes, and routing landed before I wrote any business logic. Wanted to see the surface first, then carve out what would actually pay rent.",
+      },
+      {
+        date: "2025-12-11",
+        version: "v0.2",
+        title: "Migrated provider, hooked Stripe, set the first credits floor.",
+        body: "Default Lovable wiring went through OpenAI; switched the analysis path to Google AI in the same day because the latency on the long-transcript call was unworkable. Stripe + webhook for the paid plans, audio compression for upload size, first MVP price tiers and credits UX. Day 1 in prod was a marathon.",
+        callouts: [
+          {
+            kind: "rejected",
+            label: "rejected",
+            body: "<ai>AI</ai>'s default of \"just call the LLM with the full transcript\" was fine for 2-minute clips and unusable for a 50-minute meeting. Wrote the transcription-chain spec before any more prompts.",
+          },
+        ],
+      },
+      {
+        date: "2026-Q1",
+        version: "v0.6",
+        title: "Feature-based migration. Worker modularization.",
+        body: "Moved 7 domains (auth, analysis, recording, subscription, admin, dashboard, landing) into <ai>src/features/</ai>. Broke the audio worker apart: circuit-breaker, metrics, transcription-chain, jobs/, processing/. Centralized billing config in <ai>supabase/functions/_shared/billing-config.ts</ai> so the price math has exactly one source of truth.",
+      },
+      {
+        date: "2026-05-12",
+        version: "v0.9",
+        title: "Production-readiness sweep with my own ai-squad workflow.",
+        body: "Five Sessions of SDD pipeline: regenerated a corrupted <ai>types.ts</ai>, distinguished daily vs monthly credit reset in the dashboard UI, closed 17 of 20 npm-audit vulnerabilities, satisfied <ai>react-hooks/exhaustive-deps</ai> in three files. Roadmap shows 399 tests across 69 files passing on the gate; bundle at 762 kB (gzip 234 kB) flagged as the next thing to cut.",
+        callouts: [
+          {
+            kind: "changed",
+            label: "changed by hand",
+            body: "Bumped jspdf and a Vite v7 major out of the production sweep into a backlog session. Major bumps need their own spec — not a sub-bullet in a hardening pass.",
+          },
+        ],
+      },
+      {
+        date: "2026-05-18",
+        version: "v1.0",
+        title: "Public visibility control. Staging branch workflow doc.",
+        body: "FEAT-009: non-bypassable enforcement on analysis visibility — Postgres RLS + Edge Function check + client guard, three independent layers. CLAUDE.md added documenting the staging-branch workflow so the agents don't ship straight to prod.",
+        callouts: [
+          {
+            kind: "rule",
+            label: "the rule",
+            body: "Anything touching public/private visibility runs through Postgres RLS first. Client-side toggles are convenience, not control. <ai>AI</ai> caught me trying to gate on client state once. The hook escalated it before it shipped.",
+          },
+        ],
+      },
+    ],
+    results: [
+      { value: "399", label: "tests passing · 69 files" },
+      { value: "37", label: "migrations shipped" },
+      { value: "5mo", label: "scaffold to v1.0" },
+      { value: "234kB", label: "gzip bundle · under budget" },
+    ],
+    retrospective:
+      "I started this to capture the meetings I kept losing. What it became was the project I learned my own AI workflow on. The first day was a sprint: Lovable scaffold, provider migration off OpenAI, Stripe wired, MVP credits — all before the first user. The next five months were the opposite shape: feature-based migration, worker broken into modules, billing config centralized, three layers of visibility enforcement. The lesson that stuck: <ai>AI</ai> ships the surface fast and the foundation slow. The 762 kB bundle is what happens when you let it pile up — the cleanup PR has its own session because it deserves one.",
+  },
+
+  {
+    id: "ai-squad",
+    slug: "ai-squad",
+    translationKey: "aiSquad",
+    year: "2026",
+    startedAt: "2026-05",
+    category: "AI workflow",
+    images: [],
+    skills: [skills.typescript, skills.github],
+    links: {
+      route: "/work/ai-squad",
+      github: "https://github.com/gaabscps/ai-squad",
+      changelog: "https://github.com/gaabscps/ai-squad/blob/main/CHANGELOG.md",
+    },
+    status: "live",
+    cover: {
+      kind: "screenshot",
+      src: "/ai-squad/hero.svg",
+      alt: "ai-squad overview — fuzzy idea on the left flows through Discovery (Frame, Investigate, Decide) and SDD (Specify, Plan, Tasks, Build) into shipped code on the right",
+    },
+    stackChips: ["Python stdlib", "JSON schema", "Skills + Subagents"],
+    aiTool: "Claude",
+    motivation:
+      "Using AI to code without a workflow was eating my afternoons. Built the gates I kept forgetting to walk through.",
+    motivationContext: "— april 2026, after the fourth feature I'd half-built and abandoned",
+    buildLog: [
+      {
+        date: "2026-05-03",
+        version: "v0.1.0",
+        title: "Initial architecture — Discovery + SDD squads, capped concurrency.",
+        body: "Two squads, ten roles. Discovery: Frame → Investigate → Decide. SDD: Specify → Plan → Tasks → Build. Phase 4 runs unattended with up to 5 tasks in parallel, hash-based stall detection, and a blocker-specialist that writes a decision memo when anything escalates. MIT licensed, scaffolded as a mono-repo of skills + subagents.",
+      },
+      {
+        date: "2026-05-06",
+        version: "v0.2.0",
+        title: "audit-agent + mechanical hooks. Bypass becomes impossible.",
+        body: "Prompt-discipline alone wasn't enough — Claude would happily edit files outside <ai>.agent-session/</ai> when nothing physically stopped it. Added pure-stdlib Python 3 hooks that the harness enforces: <ai>guard-session-scope</ai>, <ai>block-git-write</ai>, <ai>verify-audit-dispatch</ai>, <ai>verify-output-packet</ai>. The audit-agent is the last gate before handoff and refuses if the dispatch manifest doesn't reconcile against the output packets.",
+        callouts: [
+          {
+            kind: "rule",
+            label: "the rule",
+            body: "Discipline that lives only in a prompt is not discipline. If the agent can ignore it, eventually it will. Hooks moved every load-bearing rule from \"the prompt asks for X\" to \"the runtime refuses non-X.\"",
+          },
+        ],
+      },
+      {
+        date: "2026-05-06",
+        version: "v0.3.0",
+        title: "Three runtimes, one source. Cursor and Kiro deploy paths.",
+        body: "Same day as 0.2.0. Cursor export converts each Skill to a Cursor-compatible artifact and merges <ai>squads/sdd/hooks/cursor-hooks.json</ai> into the user's <ai>~/.cursor/hooks.json</ai>. Kiro path converts every Skill and Subagent to a Custom Agent JSON with per-agent hook wiring so <ai>guard-session-scope</ai> only fires for the orchestrator, not the dev. Three IDE targets from one set of source files.",
+      },
+      {
+        date: "2026-05-19",
+        version: "0.4 · unreleased",
+        title: "Canonical status enum + committer subagent.",
+        body: "Single source-of-truth for dispatch status lives in <ai>shared/schemas/dispatch-manifest.schema.json</ai>; Python and TypeScript consumers derive their enums from it at runtime. Added a <ai>committer</ai> subagent (haiku model) that auto-commits the working tree at the end of Phase 4 when verdict is <ai>done</ai>. Deprecated the <ai>partial</ai> status; full removal planned for vNext+1.",
+      },
+    ],
+    results: [
+      { value: "10", label: "roles in the pipeline" },
+      { value: "59/59", label: "smoke tests · PASS" },
+      { value: "3", label: "IDE runtimes · Claude / Cursor / Kiro" },
+      { value: "16d", label: "v0.1 to v0.4" },
+    ],
+    retrospective:
+      "What I wanted from this was a workflow that survived me forgetting to be disciplined. The first cut was all prompts — long, careful, full of \"you must\" language. It worked when I read every output. It failed the moment I trusted Phase 4 to run unattended. The fix was hooks: every load-bearing rule moved from \"the prompt asks\" to \"the runtime refuses.\" The second insight was multi-runtime — same Skills source, three IDE targets — because the workflow shouldn't care which editor I'm in this month. The third was the audit-agent: a single read-only reconciliation step at the end that refuses to hand off if the dispatch manifest doesn't match what actually ran. Boring, mechanical, and the reason I now trust the pipeline.",
   },
 
   {


### PR DESCRIPTION
## Summary

Expand the soundwave entry from a one-line placeholder to a full case study, and add a new ai-squad case study. Both pull every claim from the source repos:

- `/Users/gabrielandrade/Developer/projects/soundwave-summit`
- `/Users/gabrielandrade/Developer/ai-squad`

**Base:** this PR stacks on top of [#49 (BetterSMP)](https://github.com/gaabscps/gabs-portifolio/pull/49). Merge that first, then this rebases cleanly onto `master`.

## Soundwave — claims verified or corrected

| Old value | Source of truth | Action |
|---|---|---|
| `startedAt: 2025-11` | First commit in soundwave repo is `2025-12-10` (Lovable template scaffold) | Updated to `2025-12` |
| `stackChips: ["Next", "Whisper"]` | Repo is Vite + React + Supabase + Node worker on Railway; analysis migrated off OpenAI to Google AI on day two (commit 2025-12-11) | Replaced with `["Vite + React", "Supabase", "Google AI"]` |
| `category: "personal tool"` | Stripe + plans + credits + 37 migrations + dedicated worker — that's a platform, not a personal tool | Updated to `audio AI platform` |
| no `buildLog` | 5 real milestones in `git log` and `ROADMAP.md` | Added 5 entries |
| no `results` | `ROADMAP.md` dashboard: 399 tests / 69 files, 37 migrations, 234 kB gzip bundle | Added 4 stats |
| no `retrospective` | Real story arc: fast Lovable scaffold → 5 months of foundation work | Added |
| no `github` link | Repo is `gaabscps/soundwave-summit` | Added |

Build-log entries map to real events:
- `2025-12-10 v0.1` — Lovable scaffold (first commit "template: new_style_vite_react_shadcn_ts")
- `2025-12-11 v0.2` — same-day provider migration to Google AI + Stripe webhook + MVP credits UX
- `2026-Q1 v0.6` — feature-based migration (7/7 domains), worker-audio modularization (circuit-breaker, metrics, transcription-chain)
- `2026-05-12 v0.9` — production-readiness SDD sweep (Sessão 0 closed: PR-001 through PR-005)
- `2026-05-18 v1.0` — FEAT-009 non-bypassable public visibility (Postgres RLS + Edge Function + client guard, three layers)

## Ai-squad — new entry, sourced from CHANGELOG.md

| Field | Value | Source |
|---|---|---|
| `startedAt` | `2026-05` | First version v0.1.0 dated `2026-05-03` in CHANGELOG.md |
| `category` | `AI workflow` | — |
| `stackChips` | `["Python stdlib", "JSON schema", "Skills + Subagents"]` | Hooks are pure-stdlib Python; dispatch-manifest.schema.json is canonical |
| `cover` | `/ai-squad/hero.svg` | Real asset from `ai-squad/docs/assets/hero.svg`, copied to `public/ai-squad/` |
| `buildLog` | 4 entries | v0.1.0 → v0.2.0 → v0.3.0 → v0.4 unreleased (all in CHANGELOG) |
| `results` | 10 roles · 59/59 smoke pass · 3 IDE runtimes · 16-day v0.1→v0.4 | All verifiable from the repo |

Build-log entries:
- `2026-05-03 v0.1.0` — initial architecture (Discovery + SDD squads, 10 roles, capped concurrency, blocker-specialist cascade)
- `2026-05-06 v0.2.0` — audit-agent + 4 Python stdlib hooks (`guard-session-scope`, `block-git-write`, `verify-audit-dispatch`, `verify-output-packet`)
- `2026-05-06 v0.3.0` — Cursor + Kiro deploy paths (same day as v0.2.0)
- `2026-05-19 v0.4 unreleased` — canonical status enum (FEAT-006), `committer` subagent

## Other changes

- `src/app/work/[slug]/page.tsx` — added headline + lede entries for the new `ai-squad` slug
- `public/ai-squad/{hero,squads,build-pipeline}.svg` — copied from the source repo (MIT, dark-themed, already designed)

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — no warnings or errors
- [x] `npm run build` — 19 static pages generated (was 18); `/work/soundwave` and `/work/ai-squad` both in the SSG paths
- [ ] Owner: open `/work/soundwave` and `/work/ai-squad` in dev, confirm the BuildLog / Stats / Retrospective render correctly
- [ ] Owner: optionally drop `public/soundwave/preview.mp4` to use a video cover (wire-up comment in `src/data/projects.tsx` next to the current `Waveform` cover)