### PR TITLE
fix: update "three years" copy to four years pre-AI

### DIFF
--- a/REBRAND-STATUS.md
+++ b/REBRAND-STATUS.md
@@ -88,7 +88,7 @@ b5e31e6  feat(home):    add hero, featured, workshop, archive, nav, footer + Pro
 - `next.config.mjs` — 308 redirects from old project routes (`/banca-do-ingresso`, `/playx1`, `/projects`).
 
 ### Phase 4 · Legacy pages refresh
-- `src/components/About/AboutContent.tsx` — new long-form bio in English, uses Nav + Footer + new design tokens. Talks about the UNESP → late dev pivot → 3 years pre-AI → AI on time narrative.
+- `src/components/About/AboutContent.tsx` — new long-form bio in English, uses Nav + Footer + new design tokens. Talks about the UNESP → late dev pivot → 4 years pre-AI → AI on time narrative.
 - `src/components/Contact/ContactContent.tsx` — same form (WhatsApp/Telegram/email) restyled in the new system, English copy.
 - Old `app/about/AboutContent.tsx` and `app/contact/ContactContent.tsx` deleted.
 

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 import AboutContent from "@/components/About/AboutContent";
 
 const description =
-  "Gabriel Andrade, front-end engineer in São Paulo. Late pivot to code, on time for AI. Three years building production software before the AI boom.";
+  "Gabriel Andrade, front-end engineer in São Paulo. Late pivot to code, on time for AI. Four years building production software before the AI boom.";
 
 export const metadata: Metadata = {
   title: "About",

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 import HomeContent from "@/components/Home/HomeContent";
 
 const description =
-  "Front-end engineer in São Paulo. Three years shipping production software before the AI boom, now shipping with it as leverage.";
+  "Front-end engineer in São Paulo. Four years shipping production software before the AI boom, now shipping with it as leverage.";
 
 export const metadata: Metadata = {
   title: { absolute: "Gabriel Andrade · Front-end Engineer" },

--- a/src/components/About/AboutContent.tsx
+++ b/src/components/About/AboutContent.tsx
@@ -68,7 +68,7 @@ export default function AboutContent() {
         </Text>
 
         <Text fontSize="15px" color="brand.textSecondary" lineHeight={1.7} mb={5}>
-          I spent three years shipping production front-end work before the AI boom. React, Next.js, TypeScript, Chakra. Real users, real bugs, real on-call. By the time the LLMs got good, I already knew what good code looked like, and what bad code shipped feels like. That&apos;s the unfair advantage: AI accelerates everything for me because I can tell when its output is right and when it&apos;s wrong.
+          I spent four years shipping production front-end work before the AI boom. React, Next.js, TypeScript, Chakra. Real users, real bugs, real on-call. By the time the LLMs got good, I already knew what good code looked like, and what bad code shipped feels like. That&apos;s the unfair advantage: AI accelerates everything for me because I can tell when its output is right and when it&apos;s wrong.
         </Text>
 
         <Text fontSize="15px" color="brand.textSecondary" lineHeight={1.7} mb={5}>

--- a/src/components/Home/Footer.tsx
+++ b/src/components/Home/Footer.tsx
@@ -27,7 +27,7 @@ export const Footer = () => (
     <Grid templateColumns={{ base: "1fr", md: "2fr 1fr 1fr" }} gap={{ base: 8, md: 12 }}>
       <Box>
         <Text fontSize="11px" color="brand.textMeta" lineHeight={1.7} maxW="480px">
-          <Box as="span" color="brand.textSecondary">Gabriel Andrade</Box>, front-end engineer in São Paulo. UNESP Botucatu background, then a late pivot to code. Three years building without AI before catching the wave on time. Musician on weekends, gamer on weeknights.
+          <Box as="span" color="brand.textSecondary">Gabriel Andrade</Box>, front-end engineer in São Paulo. UNESP Botucatu background, then a late pivot to code. Four years building without AI before catching the wave on time. Musician on weekends, gamer on weeknights.
         </Text>
       </Box>
 

--- a/src/components/Home/Hero.tsx
+++ b/src/components/Home/Hero.tsx
@@ -49,7 +49,7 @@ export const Hero = () => (
     </Box>
 
     <Text fontSize={{ base: "14px", md: "16px" }} color="brand.textSecondary" lineHeight={1.6} maxW="544px" mb={8}>
-      Front-end engineer in São Paulo. Three years shipping production software{" "}
+      Front-end engineer in São Paulo. Four years shipping production software{" "}
       <Box as="em" color="brand.text" fontStyle="italic">before</Box>{" "}
       the AI boom. Now shipping with it as leverage, not as the demo.
     </Text>

--- a/src/components/Home/SessionTerminal/buildHomeSession.tsx
+++ b/src/components/Home/SessionTerminal/buildHomeSession.tsx
@@ -26,7 +26,7 @@ export function buildHomeSession(): SessionStep[] {
       <Text color="brand.textSecondary" lineHeight={1.7}>
         <Text as="span" color="brand.stateHelped">gabriel andrade</Text> · front-end engineer
         <br />
-        <Text as="span" color="brand.textMeta">São Paulo, BR · three years shipping before the AI boom</Text>
+        <Text as="span" color="brand.textMeta">São Paulo, BR · four years shipping before the AI boom</Text>
       </Text>
     ),
   });

--- a/src/components/Terminal/commands.ts
+++ b/src/components/Terminal/commands.ts
@@ -22,7 +22,7 @@ export const COMMANDS: Record<string, CommandHandler> = {
   ],
   whoami: () => [
     line("gabriel andrade · front-end engineer", "green"),
-    line("São Paulo, BR · three years shipping before the AI boom", "dim"),
+    line("São Paulo, BR · four years shipping before the AI boom", "dim"),
     line("now shipping with AI as leverage, not as the demo"),
   ],
   stack: () => [
@@ -49,7 +49,7 @@ export const COMMANDS: Record<string, CommandHandler> = {
     const q = args.join(" ").toLowerCase();
     let answer: string;
     if (!q) return [line('usage: ask "your question"', "error")];
-    if (q.includes("hire") || q.includes("why")) answer = "I ship. Three years of production work before the AI wave, and now I use AI to move faster without shipping the demo.";
+    if (q.includes("hire") || q.includes("why")) answer = "I ship. Four years of production work before the AI wave, and now I use AI to move faster without shipping the demo.";
     else if (q.includes("stack") || q.includes("tech")) answer = "React, Next.js and TypeScript up front; Supabase and Node behind. Run 'stack' for the full list.";
     else if (q.includes("ai")) answer = "AI writes a lot of my code now. My job is the architecture, the tests, and knowing when to stop it before it ships something that breaks.";
     else answer = "Good question. The short version: I like shipping small, correct things and improving them in the open.";


### PR DESCRIPTION
## Summary
- Career start was 2022, so the "three years shipping before the AI boom" narrative was one year stale
- Updates the copy across hero, home terminal (session + interactive commands), about page, footer, and SEO meta descriptions
- Also updates a stray reference in the internal `REBRAND-STATUS.md` notes for consistency

## Test plan
- [x] Ran the dev server and checked home (`/`) and `/about` render "four years" everywhere the old copy appeared
- [x] Grepped the repo case-insensitively for "three years" to confirm no remaining mentions