### PR TITLE
fix: compute the "live in prod" stat instead of typing it by hand

### DIFF
--- a/src/components/CaseStudy/Stats.tsx
+++ b/src/components/CaseStudy/Stats.tsx
@@ -1,6 +1,27 @@
 import { Box, Flex, Grid, Text } from "@chakra-ui/react";
 import type { Stat } from "@/types/project";
 
+const DAY = 24 * 60 * 60 * 1000;
+
+// Turns a start date into a short running duration, so stats like "live in prod"
+// count on their own. Runs on the server while the page is generated, so the
+// number is refreshed by every deploy rather than typed by hand.
+const elapsedSince = (since: string) => {
+  const days = Math.floor((Date.now() - new Date(`${since}T00:00:00Z`).getTime()) / DAY);
+  if (days < 14) {
+    return `${days}d`;
+  }
+  const weeks = Math.floor(days / 7);
+  if (weeks < 52) {
+    return `${weeks}wk`;
+  }
+  return `${Math.floor(days / 30)}mo`;
+};
+
+const statValue = (stat: Stat) => {
+  return stat.since ? elapsedSince(stat.since) : stat.value;
+};
+
 export const Stats = ({ stats, footer }: { stats: Stat[]; footer?: React.ReactNode }) => (
   <Box
     mb={10}
@@ -26,7 +47,7 @@ export const Stats = ({ stats, footer }: { stats: Stat[]; footer?: React.ReactNo
       {stats.map((s, i) => (
         <Flex key={i} align="baseline" gap={3} py={2}>
           <Text fontSize="36px" fontWeight="700" letterSpacing="-0.03em" color="brand.text" lineHeight={1}>
-            {s.value}
+            {statValue(s)}
           </Text>
           <Text
             fontSize="10px"

--- a/src/data/projects.tsx
+++ b/src/data/projects.tsx
@@ -85,7 +85,7 @@ export const projects: Project[] = [
     results: [
       { value: "0", label: "lines of Java I wrote" },
       { value: "33", label: "plugins live" },
-      { value: "12wk", label: "live in prod" },
+      { since: "2026-02-26", label: "live in prod" },
       { value: "3", label: "RPG classes live" },
     ],
     retrospective:

--- a/src/types/project.ts
+++ b/src/types/project.ts
@@ -68,9 +68,14 @@ export type BuildLogEntry = {
   callouts?: Callout[];
 };
 
+// A stat is either a fixed value ("33 plugins live") or a running duration that
+// counts from a date ("live in prod"). Set `since` instead of `value` for the
+// second kind, so the number recomputes on every build instead of being typed
+// by hand and going stale.
 export type Stat = {
-  value: string;
+  value?: string;
   label: string;
+  since?: string;
 };
 
 export type Project = {


### PR DESCRIPTION
## Why

The betterSMP case study showed **"12wk live in prod"**. That was true when it was written, around 2026-05-21, and was never updated. The server has been up since 2026-02-26, so the real number today is **23 weeks**.

This is the stat that backs the "this has been running in production for a while" claim, and it was showing about half the truth.

## What changed

A stat can now carry a start date instead of a fixed value:

```ts
{ since: "2026-02-26", label: "live in prod" }
```

The number is worked out when the page is built, so every deploy refreshes it. Under two weeks it shows days, then weeks, then months, so a brand new project never shows "0wk".

## What I deliberately did NOT change

I checked every hand-written number in the case studies. Most of them should stay as they are:

- **Fixed facts** with no source of truth in this repo: `0 lines of Java`, `33 plugins live`, `3 RPG classes live`, `399 tests`, `149 commits`, `95% type coverage`, and so on. Nothing here can compute them.
- **Spans between two past dates**: `16d · v0.1 to v0.4` (ai-squad) and `12 days · foundation to Supabase migration` (calendarfr). Both measure a window that already closed, so they cannot go stale. Deriving them would also force one counting rule on two numbers that currently count differently (one includes both end days, the other does not), which would silently change what the page shows.

**One trap worth naming:** `33 plugins live` looks like it could become `plugins.length`. It cannot. The `plugins` array lists 15 curated entries, not the full roster, so deriving it would quietly drop the number from 33 to 15 and undersell the project.

Only stats that measure "until now" can rot on their own, and `live in prod` was the only one of those on the whole site.

## Test plan
- [x] `yarn lint` clean
- [x] `npx tsc --noEmit` clean
- [x] Dev server: betterSMP now renders `23wk · live in prod`, matching the 161 days since 2026-02-26
- [x] Checked ai-squad, calendarfr and soundwave still render every stat unchanged